### PR TITLE
Revamp marketing site with new marketing components and i18n

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 VITE_SUPABASE_PROJECT_ID="eilpazegjrcrwgpujqni"
 VITE_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVpbHBhemVnanJjcndncHVqcW5pIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ1NzYxNjksImV4cCI6MjA3MDE1MjE2OX0.LV5FvbQQGf0Kv-O1uA0tsS-Yam6rB1x937BgqFsJoX4"
 VITE_SUPABASE_URL="https://eilpazegjrcrwgpujqni.supabase.co"
+
+MARKETING_V2=true

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+</urlset>

--- a/src/components/Cookies.tsx
+++ b/src/components/Cookies.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+export function Cookies(){
+  const [show,setShow] = useState(!localStorage.getItem('cookieConsent'));
+
+  const decide = (value:'accept'|'reject') => {
+    const record = {
+      value,
+      timestamp: new Date().toISOString(),
+      country: Intl.DateTimeFormat().resolvedOptions().locale.split('-')[1] || 'EU'
+    };
+    localStorage.setItem('cookieConsent', value);
+    localStorage.setItem('cookieConsentMeta', JSON.stringify(record));
+    try{ fetch('/api/consent',{method:'POST',body:JSON.stringify(record)}); }catch{}
+    (window as any).analytics?.track('cookie_choice',{ value });
+    setShow(false);
+  };
+
+  useEffect(()=>{
+    if(!localStorage.getItem('cookieConsent')){
+      localStorage.setItem('cookieConsent','reject');
+    }
+    if(localStorage.getItem('cookieConsent') !== 'accept'){
+      (window as any).analytics = undefined;
+    }
+  },[]);
+
+  if(!show) return null;
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-[var(--card)] border-t border-[var(--border)] p-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <p className="text-sm text-[var(--fg)]">We use cookies to improve your experience.</p>
+      <div className="flex gap-2">
+        <button aria-label="Accept cookies" className="rounded bg-[var(--brand)] text-[var(--brand-contrast)] px-4 py-2" onClick={()=>decide('accept')}>Accept</button>
+        <button aria-label="Reject cookies" className="rounded border border-[var(--border)] px-4 py-2" onClick={()=>decide('reject')}>Reject</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LegalFooter.tsx
+++ b/src/components/LegalFooter.tsx
@@ -1,0 +1,14 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export function LegalFooter(){
+  const { t } = useI18n();
+  return (
+    <footer className="py-6 text-sm text-center text-[var(--muted)]">
+      <div className="flex justify-center gap-4">
+        <a href="/privacy" aria-label={t("legal.privacy")} className="hover:underline">{t("legal.privacy")}</a>
+        <a href="/terms" aria-label={t("legal.terms")} className="hover:underline">{t("legal.terms")}</a>
+        <a href="/cookies" aria-label={t("legal.cookies")} className="hover:underline">{t("legal.cookies")}</a>
+      </div>
+    </footer>
+  );
+}

--- a/src/hooks/useI18n.ts
+++ b/src/hooks/useI18n.ts
@@ -1,0 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
+export function useI18n() {
+  return useTranslation('marketing');
+}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -24,6 +24,7 @@ import securityEn from '@/locales/en/security.json';
 import workspaceEn from '@/locales/en/workspace.json';
 import billingEn from '@/locales/en/billing.json';
 import errorsEn from '@/locales/en/errors.json';
+import marketingEn from './en.json';
 
 import commonFr from '@/locales/fr/common.json';
 import homeFr from '@/locales/fr/home.json';
@@ -46,6 +47,7 @@ import securityFr from '@/locales/fr/security.json';
 import workspaceFr from '@/locales/fr/workspace.json';
 import billingFr from '@/locales/fr/billing.json';
 import errorsFr from '@/locales/fr/errors.json';
+import marketingFr from './fr.json';
 
 // Import ES/PT/IT locale files
 import commonEs from '@/locales/es/common.json';
@@ -56,6 +58,7 @@ import legalEs from '@/locales/es/legal.json';
 import galleryEs from '@/locales/es/gallery.json';
 import contactEs from '@/locales/es/contact.json';
 import pricingEs from '@/locales/es/pricing.json';
+import marketingEs from './es.json';
 
 import commonPt from '@/locales/pt/common.json';
 import homePt from '@/locales/pt/home.json';
@@ -65,6 +68,7 @@ import legalPt from '@/locales/pt/legal.json';
 import galleryPt from '@/locales/pt/gallery.json';
 import contactPt from '@/locales/pt/contact.json';
 import pricingPt from '@/locales/pt/pricing.json';
+import marketingPt from './pt.json';
 
 import commonIt from '@/locales/it/common.json';
 import homeIt from '@/locales/it/home.json';
@@ -74,6 +78,7 @@ import legalIt from '@/locales/it/legal.json';
 import galleryIt from '@/locales/it/gallery.json';
 import contactIt from '@/locales/it/contact.json';
 import pricingIt from '@/locales/it/pricing.json';
+import marketingIt from './it.json';
 
 // Supported locales
 export const supportedLocales = [
@@ -105,6 +110,7 @@ const resources = {
     workspace: workspaceEn,
     billing: billingEn,
     errors: errorsEn,
+    marketing: marketingEn,
   },
   fr: {
     common: commonFr,
@@ -128,6 +134,7 @@ const resources = {
     workspace: workspaceFr,
     billing: billingFr,
     errors: errorsFr,
+    marketing: marketingFr,
   },
   es: {
     common: commonEs,
@@ -152,6 +159,7 @@ const resources = {
     progress: progressEn,
     security: securityEn,
     workspace: workspaceEn,
+    marketing: marketingEs,
   },
   pt: {
     common: commonPt,
@@ -176,6 +184,7 @@ const resources = {
     progress: progressEn,
     security: securityEn,
     workspace: workspaceEn,
+    marketing: marketingPt,
   },
   it: {
     common: commonIt,
@@ -200,6 +209,7 @@ const resources = {
     progress: progressEn,
     security: securityEn,
     workspace: workspaceEn,
+    marketing: marketingIt,
   }
 };
 
@@ -227,7 +237,7 @@ i18n
       useSuspense: false,
     },
 
-    ns: ['common', 'home', 'features', 'pricing', 'gallery', 'faq', 'contact', 'legal', 'onboarding', 'design', 'progress', 'preview', 'dashboard', 'analytics', 'domain', 'backup', 'cache', 'security', 'workspace', 'billing', 'errors'],
+    ns: ['common', 'home', 'features', 'pricing', 'gallery', 'faq', 'contact', 'legal', 'onboarding', 'design', 'progress', 'preview', 'dashboard', 'analytics', 'domain', 'backup', 'cache', 'security', 'workspace', 'billing', 'errors', 'marketing'],
     defaultNS: 'common',
   });
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,106 @@
+{
+  "hero": {
+    "title": "Launch a professional website in minutes, not weeks.",
+    "subtitle": "Describe your business, let AI build, customize with drag‑and‑drop, publish with EU‑grade hosting. GDPR compliant.",
+    "ctaPrimary": "Create my site",
+    "ctaSecondary": "See plans"
+  },
+  "steps": {
+    "title": "How it works",
+    "s1": "Describe your business",
+    "s2": "Customize with the editor",
+    "s3": "Publish with a domain",
+    "s4": "Grow with blog and e‑commerce"
+  },
+  "features": {
+    "title": "Built for EU businesses",
+    "f1": "AI site generation",
+    "f2": "Drag‑and‑drop editor",
+    "f3": "Mobile‑first design",
+    "f4": "Free SSL certificate",
+    "f5": "EU hosting, 99.99% uptime",
+    "f6": "Automatic backups",
+    "f7": "Cookie banner + consent logs",
+    "f8": "SEO basics and fast load"
+  },
+  "pricing": {
+    "title": "Pricing",
+    "vatToggle": "Show prices incl. VAT",
+    "periodToggleMonthly": "Monthly",
+    "periodToggleYearly": "Yearly (save 20%)",
+    "starter": {
+      "name": "Starter",
+      "price": "€59",
+      "tagline": "Everything to launch fast",
+      "features": [
+        "AI website generation",
+        "Up to 5 pages",
+        "Drag‑and‑drop editor",
+        "Hosting included",
+        "1 custom domain (1 year)",
+        "Free SSL",
+        "Automatic backups",
+        "Email support"
+      ],
+      "cta": "Start Starter"
+    },
+    "business": {
+      "name": "Business",
+      "price": "€119",
+      "tagline": "Grow with content and shop",
+      "features": [
+        "Everything in Starter",
+        "Unlimited pages",
+        "Blog included",
+        "WooCommerce",
+        "AI Copilot in editor",
+        "Visitors analytics",
+        "Advanced backups + restore",
+        "Priority human support"
+      ],
+      "cta": "Start Business"
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "price": "Talk to sales",
+      "tagline": "Custom features, scale, and SLAs",
+      "features": [
+        "Custom integrations",
+        "Multi‑site and SSO",
+        "Dedicated infrastructure",
+        "Advanced security & monitoring",
+        "24/7 support with SLA"
+      ],
+      "cta": "Book a call"
+    },
+    "disclaimer": "Annual billing: domain is free for year one; renewal billed separately."
+  },
+  "socialProof": {
+    "title": "Trusted by EU SMBs",
+    "t1": "“Live in one day. The editor is simple.”",
+    "t2": "“Great speed scores and clear pricing.”"
+  },
+  "faq": {
+    "title": "FAQ",
+    "q1": "Is it GDPR compliant?",
+    "a1": "Yes. Data is processed in the EU where possible, cookie consent is recorded, and you control data exports/deletion.",
+    "q2": "Is a domain included?",
+    "a2": "One custom domain is included for the first year on all paid plans. Renewal is separate.",
+    "q3": "Can I cancel anytime?",
+    "a3": "Yes. Cancel anytime from your dashboard.",
+    "q4": "Do you support e‑commerce?",
+    "a4": "Yes, WooCommerce is included in Business and above.",
+    "q5": "Do you offer human support?",
+    "a5": "Email support on Starter. Priority human support on Business. 24/7 SLA on Enterprise."
+  },
+  "ctaFinal": {
+    "title": "Get online today",
+    "subtitle": "Your website ready in minutes.",
+    "cta": "Create my site"
+  },
+  "legal": {
+    "privacy": "Privacy",
+    "terms": "Terms",
+    "cookies": "Cookies"
+  }
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,106 @@
+{
+  "hero": {
+    "title": "Tu web profesional en minutos, no en semanas.",
+    "subtitle": "Describe tu negocio, deja que la IA construya, personaliza con arrastrar y soltar, publica con alojamiento de nivel UE. Cumple con RGPD.",
+    "ctaPrimary": "Crear mi sitio",
+    "ctaSecondary": "Ver planes"
+  },
+  "steps": {
+    "title": "Cómo funciona",
+    "s1": "Describe tu negocio",
+    "s2": "Personaliza con el editor",
+    "s3": "Publica con un dominio",
+    "s4": "Crece con blog y comercio electrónico"
+  },
+  "features": {
+    "title": "Pensado para empresas de la UE",
+    "f1": "Generación de sitios con IA",
+    "f2": "Editor de arrastrar y soltar",
+    "f3": "Diseño mobile-first",
+    "f4": "Certificado SSL gratuito",
+    "f5": "Alojamiento en la UE, 99,99% de uptime",
+    "f6": "Copias de seguridad automáticas",
+    "f7": "Banner de cookies y registros de consentimiento",
+    "f8": "SEO básico y carga rápida"
+  },
+  "pricing": {
+    "title": "Precios",
+    "vatToggle": "Mostrar precios con IVA",
+    "periodToggleMonthly": "Mensual",
+    "periodToggleYearly": "Anual (ahorra 20%)",
+    "starter": {
+      "name": "Starter",
+      "price": "59 €",
+      "tagline": "Todo para lanzar rápido",
+      "features": [
+        "Generación de sitio con IA",
+        "Hasta 5 páginas",
+        "Editor de arrastrar y soltar",
+        "Alojamiento incluido",
+        "1 dominio personalizado (1 año)",
+        "SSL gratuito",
+        "Copias de seguridad automáticas",
+        "Soporte por email"
+      ],
+      "cta": "Elegir Starter"
+    },
+    "business": {
+      "name": "Business",
+      "price": "119 €",
+      "tagline": "Crece con contenido y tienda",
+      "features": [
+        "Todo en Starter",
+        "Páginas ilimitadas",
+        "Blog incluido",
+        "WooCommerce",
+        "Copiloto IA en el editor",
+        "Analítica de visitantes",
+        "Copias de seguridad avanzadas + restauración",
+        "Soporte humano prioritario"
+      ],
+      "cta": "Elegir Business"
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "price": "Habla con ventas",
+      "tagline": "Funciones a medida, escala y SLA",
+      "features": [
+        "Integraciones personalizadas",
+        "Multi‑sitio y SSO",
+        "Infraestructura dedicada",
+        "Seguridad y monitorización avanzadas",
+        "Soporte 24/7 con SLA"
+      ],
+      "cta": "Reservar una llamada"
+    },
+    "disclaimer": "Facturación anual: el dominio es gratis el primer año; renovación facturada por separado."
+  },
+  "socialProof": {
+    "title": "Confiado por pymes de la UE",
+    "t1": "“En vivo en un día. El editor es sencillo.”",
+    "t2": "“Grandes puntuaciones de velocidad y precios claros.”"
+  },
+  "faq": {
+    "title": "FAQ",
+    "q1": "¿Cumple con el RGPD?",
+    "a1": "Sí. Los datos se procesan en la UE cuando es posible, se registra el consentimiento de cookies y controlas exportaciones/eliminación de datos.",
+    "q2": "¿Incluye un dominio?",
+    "a2": "Un dominio personalizado está incluido el primer año en todos los planes de pago. La renovación es aparte.",
+    "q3": "¿Puedo cancelar en cualquier momento?",
+    "a3": "Sí. Cancela en cualquier momento desde tu panel.",
+    "q4": "¿Ofrecéis comercio electrónico?",
+    "a4": "Sí, WooCommerce está incluido en Business y superiores.",
+    "q5": "¿Ofrecéis soporte humano?",
+    "a5": "Soporte por email en Starter. Soporte humano prioritario en Business. SLA 24/7 en Enterprise."
+  },
+  "ctaFinal": {
+    "title": "Conéctate hoy",
+    "subtitle": "Tu web lista en minutos.",
+    "cta": "Crear mi sitio"
+  },
+  "legal": {
+    "privacy": "Privacidad",
+    "terms": "Términos",
+    "cookies": "Cookies"
+  }
+}

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,0 +1,106 @@
+{
+  "hero": {
+    "title": "Votre site professionnel en quelques minutes, pas en quelques semaines.",
+    "subtitle": "Décrivez votre activité, laissez l'IA construire, personnalisez par glisser‑déposer, publiez avec un hébergement de niveau UE. Conforme RGPD.",
+    "ctaPrimary": "Créer mon site",
+    "ctaSecondary": "Voir les offres"
+  },
+  "steps": {
+    "title": "Comment ça marche",
+    "s1": "Décrivez votre activité",
+    "s2": "Personnalisez avec l'éditeur",
+    "s3": "Publiez avec un domaine",
+    "s4": "Développez avec blog et e‑commerce"
+  },
+  "features": {
+    "title": "Conçu pour les entreprises de l'UE",
+    "f1": "Génération de site par IA",
+    "f2": "Éditeur drag‑and‑drop",
+    "f3": "Design mobile‑first",
+    "f4": "Certificat SSL gratuit",
+    "f5": "Hébergement UE, 99,99% de disponibilité",
+    "f6": "Sauvegardes automatiques",
+    "f7": "Bannière de cookies + journaux de consentement",
+    "f8": "SEO de base et chargement rapide"
+  },
+  "pricing": {
+    "title": "Tarifs",
+    "vatToggle": "Afficher les prix TTC",
+    "periodToggleMonthly": "Mensuel",
+    "periodToggleYearly": "Annuel (économisez 20%)",
+    "starter": {
+      "name": "Starter",
+      "price": "€59",
+      "tagline": "Tout pour lancer vite",
+      "features": [
+        "Génération de site par IA",
+        "Jusqu'à 5 pages",
+        "Éditeur drag‑and‑drop",
+        "Hébergement inclus",
+        "1 domaine personnalisé (1 an)",
+        "SSL gratuit",
+        "Sauvegardes automatiques",
+        "Support par e‑mail"
+      ],
+      "cta": "Choisir Starter"
+    },
+    "business": {
+      "name": "Business",
+      "price": "€119",
+      "tagline": "Développez avec contenu et boutique",
+      "features": [
+        "Tout dans Starter",
+        "Pages illimitées",
+        "Blog inclus",
+        "WooCommerce",
+        "Copilot IA dans l'éditeur",
+        "Analytique visiteurs",
+        "Sauvegardes avancées + restauration",
+        "Support humain prioritaire"
+      ],
+      "cta": "Choisir Business"
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "price": "Contactez les ventes",
+      "tagline": "Fonctionnalités sur mesure, scalabilité et SLA",
+      "features": [
+        "Intégrations personnalisées",
+        "Multi‑site et SSO",
+        "Infrastructure dédiée",
+        "Sécurité et surveillance avancées",
+        "Support 24/7 avec SLA"
+      ],
+      "cta": "Réserver un appel"
+    },
+    "disclaimer": "Facturation annuelle : le domaine est gratuit la première année ; renouvellement facturé séparément."
+  },
+  "socialProof": {
+    "title": "Adopté par les PME européennes",
+    "t1": "« En ligne en une journée. L'éditeur est simple. »",
+    "t2": "« Excellentes notes de vitesse et tarification claire. »"
+  },
+  "faq": {
+    "title": "FAQ",
+    "q1": "Est‑ce conforme au RGPD ?",
+    "a1": "Oui. Les données sont traitées dans l'UE lorsque possible, le consentement aux cookies est enregistré, et vous contrôlez l'export/suppression des données.",
+    "q2": "Un domaine est‑il inclus ?",
+    "a2": "Un domaine personnalisé est inclus la première année sur toutes les offres payantes. Le renouvellement est séparé.",
+    "q3": "Puis‑je annuler à tout moment ?",
+    "a3": "Oui. Annulez à tout moment depuis votre tableau de bord.",
+    "q4": "Proposez‑vous l'e‑commerce ?",
+    "a4": "Oui, WooCommerce est inclus dans l'offre Business et plus.",
+    "q5": "Offrez‑vous un support humain ?",
+    "a5": "Support par e‑mail sur Starter. Support humain prioritaire sur Business. SLA 24/7 sur Enterprise."
+  },
+  "ctaFinal": {
+    "title": "Mettez-vous en ligne dès aujourd'hui",
+    "subtitle": "Votre site prêt en quelques minutes.",
+    "cta": "Créer mon site"
+  },
+  "legal": {
+    "privacy": "Confidentialité",
+    "terms": "Conditions",
+    "cookies": "Cookies"
+  }
+}

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1,0 +1,106 @@
+{
+  "hero": {
+    "title": "Il tuo sito professionale in pochi minuti, non in settimane.",
+    "subtitle": "Descrivi la tua attività, lascia che l'IA costruisca, personalizza con drag‑and‑drop, pubblica con hosting di livello UE. Conforme al GDPR.",
+    "ctaPrimary": "Crea il mio sito",
+    "ctaSecondary": "Vedi i piani"
+  },
+  "steps": {
+    "title": "Come funziona",
+    "s1": "Descrivi la tua attività",
+    "s2": "Personalizza con l'editor",
+    "s3": "Pubblica con un dominio",
+    "s4": "Cresci con blog e e‑commerce"
+  },
+  "features": {
+    "title": "Pensato per le aziende UE",
+    "f1": "Generazione sito con IA",
+    "f2": "Editor drag‑and‑drop",
+    "f3": "Design mobile-first",
+    "f4": "Certificato SSL gratuito",
+    "f5": "Hosting UE, 99,99% uptime",
+    "f6": "Backup automatici",
+    "f7": "Banner cookie e registri di consenso",
+    "f8": "SEO base e caricamento veloce"
+  },
+  "pricing": {
+    "title": "Prezzi",
+    "vatToggle": "Mostra prezzi IVA incl.",
+    "periodToggleMonthly": "Mensile",
+    "periodToggleYearly": "Annuale (risparmia 20%)",
+    "starter": {
+      "name": "Starter",
+      "price": "€59",
+      "tagline": "Tutto per lanciare subito",
+      "features": [
+        "Generazione sito con IA",
+        "Fino a 5 pagine",
+        "Editor drag‑and‑drop",
+        "Hosting incluso",
+        "1 dominio personalizzato (1 anno)",
+        "SSL gratuito",
+        "Backup automatici",
+        "Supporto email"
+      ],
+      "cta": "Scegli Starter"
+    },
+    "business": {
+      "name": "Business",
+      "price": "€119",
+      "tagline": "Cresci con contenuti e shop",
+      "features": [
+        "Tutto in Starter",
+        "Pagine illimitate",
+        "Blog incluso",
+        "WooCommerce",
+        "Copilot IA nell'editor",
+        "Analytics visitatori",
+        "Backup avanzati + ripristino",
+        "Supporto umano prioritario"
+      ],
+      "cta": "Scegli Business"
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "price": "Parla con le vendite",
+      "tagline": "Funzioni su misura, scala e SLA",
+      "features": [
+        "Integrazioni personalizzate",
+        "Multi‑sito e SSO",
+        "Infrastruttura dedicata",
+        "Sicurezza e monitoraggio avanzati",
+        "Supporto 24/7 con SLA"
+      ],
+      "cta": "Prenota una call"
+    },
+    "disclaimer": "Fatturazione annuale: il dominio è gratuito per il primo anno; rinnovo fatturato a parte."
+  },
+  "socialProof": {
+    "title": "Scelto dalle PMI europee",
+    "t1": "“Online in un giorno. L'editor è semplice.”",
+    "t2": "“Ottimi punteggi di velocità e prezzi chiari.”"
+  },
+  "faq": {
+    "title": "FAQ",
+    "q1": "È conforme al GDPR?",
+    "a1": "Sì. I dati sono trattati nell'UE quando possibile, il consenso ai cookie è registrato e controlli esportazioni/eliminazione dei dati.",
+    "q2": "È incluso un dominio?",
+    "a2": "Un dominio personalizzato è incluso per il primo anno in tutti i piani a pagamento. Il rinnovo è separato.",
+    "q3": "Posso annullare in qualsiasi momento?",
+    "a3": "Sì. Puoi annullare in qualsiasi momento dal tuo dashboard.",
+    "q4": "Supportate l'e‑commerce?",
+    "a4": "Sì, WooCommerce è incluso in Business e oltre.",
+    "q5": "Offrite supporto umano?",
+    "a5": "Supporto email su Starter. Supporto umano prioritario su Business. SLA 24/7 su Enterprise."
+  },
+  "ctaFinal": {
+    "title": "Mettiti online oggi",
+    "subtitle": "Il tuo sito pronto in pochi minuti.",
+    "cta": "Crea il mio sito"
+  },
+  "legal": {
+    "privacy": "Privacy",
+    "terms": "Termini",
+    "cookies": "Cookie"
+  }
+}

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -1,0 +1,106 @@
+{
+  "hero": {
+    "title": "O seu site profissional em minutos, não em semanas.",
+    "subtitle": "Descreva o seu negócio, deixe a IA construir, personalize com arrastar e soltar, publique com hospedagem nível UE. Em conformidade com RGPD.",
+    "ctaPrimary": "Criar meu site",
+    "ctaSecondary": "Ver planos"
+  },
+  "steps": {
+    "title": "Como funciona",
+    "s1": "Descreva o seu negócio",
+    "s2": "Personalize com o editor",
+    "s3": "Publique com um domínio",
+    "s4": "Cresça com blog e e‑commerce"
+  },
+  "features": {
+    "title": "Feito para empresas da UE",
+    "f1": "Geração de site por IA",
+    "f2": "Editor de arrastar e soltar",
+    "f3": "Design mobile-first",
+    "f4": "Certificado SSL gratuito",
+    "f5": "Hospedagem na UE, 99,99% de uptime",
+    "f6": "Backups automáticos",
+    "f7": "Banner de cookies e registos de consentimento",
+    "f8": "SEO básico e carregamento rápido"
+  },
+  "pricing": {
+    "title": "Preços",
+    "vatToggle": "Mostrar preços com IVA",
+    "periodToggleMonthly": "Mensal",
+    "periodToggleYearly": "Anual (poupe 20%)",
+    "starter": {
+      "name": "Starter",
+      "price": "€59",
+      "tagline": "Tudo para lançar rápido",
+      "features": [
+        "Geração de site por IA",
+        "Até 5 páginas",
+        "Editor de arrastar e soltar",
+        "Hospedagem incluída",
+        "1 domínio personalizado (1 ano)",
+        "SSL gratuito",
+        "Backups automáticos",
+        "Suporte por e‑mail"
+      ],
+      "cta": "Escolher Starter"
+    },
+    "business": {
+      "name": "Business",
+      "price": "€119",
+      "tagline": "Cresça com conteúdo e loja",
+      "features": [
+        "Tudo no Starter",
+        "Páginas ilimitadas",
+        "Blog incluído",
+        "WooCommerce",
+        "Copiloto IA no editor",
+        "Analítica de visitantes",
+        "Backups avançados + restauro",
+        "Suporte humano prioritário"
+      ],
+      "cta": "Escolher Business"
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "price": "Fale com vendas",
+      "tagline": "Funcionalidades personalizadas, escala e SLA",
+      "features": [
+        "Integrações personalizadas",
+        "Multi‑site e SSO",
+        "Infraestrutura dedicada",
+        "Segurança e monitorização avançadas",
+        "Suporte 24/7 com SLA"
+      ],
+      "cta": "Marcar uma chamada"
+    },
+    "disclaimer": "Cobrança anual: domínio gratuito no primeiro ano; renovação cobrada em separado."
+  },
+  "socialProof": {
+    "title": "Confiado por PMEs da UE",
+    "t1": "“Online em um dia. O editor é simples.”",
+    "t2": "“Ótimas pontuações de velocidade e preços claros.”"
+  },
+  "faq": {
+    "title": "FAQ",
+    "q1": "É compatível com o RGPD?",
+    "a1": "Sim. Os dados são processados na UE quando possível, o consentimento de cookies é registado e você controla exportações/eliminação de dados.",
+    "q2": "Um domínio está incluído?",
+    "a2": "Um domínio personalizado está incluído no primeiro ano em todos os planos pagos. A renovação é separada.",
+    "q3": "Posso cancelar a qualquer momento?",
+    "a3": "Sim. Cancele a qualquer momento no seu painel.",
+    "q4": "Suportam e‑commerce?",
+    "a4": "Sim, o WooCommerce está incluído no Business e acima.",
+    "q5": "Oferecem suporte humano?",
+    "a5": "Suporte por e‑mail no Starter. Suporte humano prioritário no Business. SLA 24/7 no Enterprise."
+  },
+  "ctaFinal": {
+    "title": "Fique online hoje",
+    "subtitle": "O seu site pronto em minutos.",
+    "cta": "Criar meu site"
+  },
+  "legal": {
+    "privacy": "Privacidade",
+    "terms": "Termos",
+    "cookies": "Cookies"
+  }
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useI18n } from '@/hooks/useI18n';
+
+export function useHomeSEO(){
+  const { t } = useI18n();
+  useEffect(()=>{
+    document.title = t('hero.title');
+    let meta = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+    if(!meta){
+      meta = document.createElement('meta');
+      meta.setAttribute('name','description');
+      document.head.appendChild(meta);
+    }
+    meta.setAttribute('content', t('hero.subtitle'));
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.innerHTML = JSON.stringify({
+      "@context":"https://schema.org",
+      "@type":"Organization",
+      "name":"Naveeg",
+      "address":{"@type":"PostalAddress","addressCountry":"EU"},
+      "sameAs":[
+        "https://twitter.com/naveeg",
+        "https://www.linkedin.com/company/naveeg"
+      ]
+    });
+    document.head.appendChild(script);
+    return () => { script.remove(); };
+  },[t]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 // optional: import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { routeTree } from "./routeTree.gen";
 import "./index.css";
+import "./styles/tokens.css";
+import "./i18n/config";
 
 const router = createRouter({ routeTree });
 const queryClient = new QueryClient();

--- a/src/pages/cookies.tsx
+++ b/src/pages/cookies.tsx
@@ -1,0 +1,10 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export default function CookiesPage(){
+  const { t } = useI18n();
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-semibold">{t("legal.cookies")}</h1>
+    </main>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,37 @@
+import { Hero } from '@/sections/Hero';
+import { Steps } from '@/sections/Steps';
+import { Features } from '@/sections/Features';
+import { Pricing } from '@/sections/Pricing';
+import { Testimonials } from '@/sections/Testimonials';
+import { FAQ } from '@/sections/FAQ';
+import { FinalCTA } from '@/sections/FinalCTA';
+import { LegalFooter } from '@/components/LegalFooter';
+import { Cookies } from '@/components/Cookies';
+import { useHomeSEO } from '@/lib/seo';
+
+function LegacyHome(){
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold">Naveeg</h1>
+      <p className="mt-2 text-sm opacity-70">Digital marketing tools that ship.</p>
+    </main>
+  );
+}
+
+export default function Home(){
+  if(!import.meta.env.MARKETING_V2) return <LegacyHome/>;
+  useHomeSEO();
+  return (
+    <>
+      <Hero/>
+      <Steps/>
+      <Features/>
+      <Pricing/>
+      <Testimonials/>
+      <FAQ/>
+      <FinalCTA/>
+      <LegalFooter/>
+      <Cookies/>
+    </>
+  );
+}

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,0 +1,10 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export default function Privacy(){
+  const { t } = useI18n();
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-semibold">{t("legal.privacy")}</h1>
+    </main>
+  );
+}

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,0 +1,10 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export default function Terms(){
+  const { t } = useI18n();
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-semibold">{t("legal.terms")}</h1>
+    </main>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { supabase } from "@/lib/supabase";
+import Home from "@/pages/index";
 
 export const Route = createFileRoute("/")({
   async beforeLoad() {
@@ -13,14 +14,5 @@ export const Route = createFileRoute("/")({
     const first = !error && data?.[0]?.website_id;
     if (first) throw redirect({ to: `/${data![0].website_id}/overview` });
   },
-  component: Marketing,
+  component: Home,
 });
-
-function Marketing() {
-  return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold">Naveeg</h1>
-      <p className="mt-2 text-sm opacity-70">Digital marketing tools that ship.</p>
-    </main>
-  );
-}

--- a/src/sections/FAQ.tsx
+++ b/src/sections/FAQ.tsx
@@ -1,0 +1,21 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export function FAQ(){
+  const { t } = useI18n();
+  const items = [1,2,3,4,5];
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-6xl px-6">
+        <h2 className="text-3xl font-semibold">{t("faq.title")}</h2>
+        <div className="mt-8 space-y-4">
+          {items.map(i=>(
+            <details key={i} className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+              <summary aria-label={t(`faq.q${i}`)} className="cursor-pointer font-medium">{t(`faq.q${i}`)}</summary>
+              <p className="mt-2">{t(`faq.a${i}`)}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Features.tsx
+++ b/src/sections/Features.tsx
@@ -1,0 +1,20 @@
+import { useI18n } from '@/hooks/useI18n';
+
+const keys = ["f1","f2","f3","f4","f5","f6","f7","f8"];
+export function Features(){
+  const { t } = useI18n();
+  return (
+    <section className="py-16 bg-[var(--bg)]">
+      <div className="mx-auto max-w-6xl px-6">
+        <h2 className="text-3xl font-semibold">{t("features.title")}</h2>
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {keys.map(k=>(
+            <div key={k} className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+              <p>{t(`features.${k}`)}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/FinalCTA.tsx
+++ b/src/sections/FinalCTA.tsx
@@ -1,0 +1,14 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export function FinalCTA(){
+  const { t } = useI18n();
+  return (
+    <section className="py-16 bg-[var(--bg)] text-center">
+      <div className="mx-auto max-w-6xl px-6">
+        <h2 className="text-3xl font-semibold">{t("ctaFinal.title")}</h2>
+        <p className="mt-4 text-lg text-[var(--muted)]">{t("ctaFinal.subtitle")}</p>
+        <a href="/signup" aria-label={t("ctaFinal.cta")} className="mt-8 inline-block rounded-xl bg-[var(--brand)] px-6 py-3 text-[var(--brand-contrast)]">{t("ctaFinal.cta")}</a>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,0 +1,28 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export function Hero(){
+  const { t } = useI18n();
+  const track = () => {
+    if(localStorage.getItem('cookieConsent') === 'accept'){
+      (window as any).analytics?.track('hero_cta_click');
+    }
+  };
+  return (
+    <section className="bg-[var(--bg)] text-[var(--fg)]">
+      <div className="mx-auto max-w-6xl px-6 py-16 grid gap-6 md:grid-cols-2 items-center">
+        <div>
+          <h1 className="text-4xl md:text-5xl font-bold">{t("hero.title")}</h1>
+          <p className="mt-4 text-lg text-[var(--muted)]">{t("hero.subtitle")}</p>
+          <div className="mt-8 flex gap-3">
+            <a href="/signup" aria-label={t("hero.ctaPrimary")} onClick={track} className="btn btn-lg rounded-xl px-6 py-3 bg-[var(--brand)] text-[var(--brand-contrast)]">{t("hero.ctaPrimary")}</a>
+            <a href="#pricing" aria-label={t("hero.ctaSecondary")} className="btn btn-lg rounded-xl px-6 py-3 border border-[var(--border)]">{t("hero.ctaSecondary")}</a>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-[var(--border)] p-4 bg-[var(--card)]">
+          {/* Replace with product mockup image */}
+          <div className="aspect-video rounded-lg bg-neutral-100 dark:bg-neutral-800" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Pricing.tsx
+++ b/src/sections/Pricing.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { useI18n } from '@/hooks/useI18n';
+
+type Plan = "starter"|"business"|"enterprise";
+const base = { starter:59, business:119 } as const;
+const VAT = 0.20;
+
+function price(num:number, yearly:boolean, vat:boolean){
+  const m = yearly ? (num*12*0.8) : num; // 20% off yearly
+  const v = vat ? m*(1+VAT) : m;
+  return yearly ? `€${v.toFixed(2)}/yr` : `€${v.toFixed(2)}/mo`;
+}
+
+export function Pricing(){
+  const { t } = useI18n();
+  const [yearly,setYearly] = useState(false);
+  const [vat,setVat] = useState(false);
+  const plans:Plan[]=["starter","business","enterprise"];
+  const features:Record<Plan,string[]> = {
+    starter: t("pricing.starter.features") as unknown as string[],
+    business: t("pricing.business.features") as unknown as string[],
+    enterprise: t("pricing.enterprise.features") as unknown as string[],
+  };
+  const track = (plan:Plan) => {
+    if(localStorage.getItem('cookieConsent') === 'accept'){
+      (window as any).analytics?.track('pricing_cta_click',{ plan, yearly, vat });
+    }
+  };
+  return (
+    <section id="pricing" className="py-16">
+      <div className="mx-auto max-w-6xl px-6">
+        <h2 className="text-3xl font-semibold">{t("pricing.title")}</h2>
+
+        <div className="mt-4 flex items-center gap-4">
+          <label className="flex items-center gap-2">
+            <input type="checkbox" aria-label={t("pricing.periodToggleYearly")} checked={yearly} onChange={e=>setYearly(e.target.checked)} />
+            <span>{t("pricing.periodToggleYearly")}</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="checkbox" aria-label={t("pricing.vatToggle")} checked={vat} onChange={e=>setVat(e.target.checked)} />
+            <span>{t("pricing.vatToggle")}</span>
+          </label>
+        </div>
+
+        <div className="mt-8 grid gap-6 md:grid-cols-3">
+          {/* Starter */}
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6">
+            <h3 className="text-2xl font-semibold">{t("pricing.starter.name")}</h3>
+            <p className="text-[var(--muted)]">{t("pricing.starter.tagline")}</p>
+            <p className="mt-4 text-3xl font-bold">
+              {price(base.starter, yearly, vat)}
+            </p>
+            <ul className="mt-4 space-y-2">
+              {features.starter.map((f,i)=>(<li key={i}>• {f}</li>))}
+            </ul>
+            <a href="/signup?plan=starter" aria-label={t("pricing.starter.cta")} onClick={()=>track('starter')} className="mt-6 inline-block rounded-xl bg-[var(--brand)] px-5 py-3 text-[var(--brand-contrast)]">
+              {t("pricing.starter.cta")}
+            </a>
+          </div>
+
+          {/* Business */}
+          <div className="rounded-2xl border-2 border-[var(--brand)] bg-[var(--card)] p-6 shadow-lg">
+            <h3 className="text-2xl font-semibold">{t("pricing.business.name")}</h3>
+            <p className="text-[var(--muted)]">{t("pricing.business.tagline")}</p>
+            <p className="mt-4 text-3xl font-bold">
+              {price(base.business, yearly, vat)}
+            </p>
+            <ul className="mt-4 space-y-2">
+              {features.business.map((f,i)=>(<li key={i}>• {f}</li>))}
+            </ul>
+            <a href="/signup?plan=business" aria-label={t("pricing.business.cta")} onClick={()=>track('business')} className="mt-6 inline-block rounded-xl bg-[var(--brand)] px-5 py-3 text-[var(--brand-contrast)]">
+              {t("pricing.business.cta")}
+            </a>
+          </div>
+
+          {/* Enterprise */}
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6">
+            <h3 className="text-2xl font-semibold">{t("pricing.enterprise.name")}</h3>
+            <p className="text-[var(--muted)]">{t("pricing.enterprise.tagline")}</p>
+            <p className="mt-4 text-3xl font-bold">{t("pricing.enterprise.price")}</p>
+            <ul className="mt-4 space-y-2">
+              {features.enterprise.map((f,i)=>(<li key={i}>• {f}</li>))}
+            </ul>
+            <a href="/contact?sales=1" aria-label={t("pricing.enterprise.cta")} onClick={()=>track('enterprise')} className="mt-6 inline-block rounded-xl border border-[var(--border)] px-5 py-3">
+              {t("pricing.enterprise.cta")}
+            </a>
+          </div>
+        </div>
+
+        <p className="mt-4 text-sm text-[var(--muted)]">{t("pricing.disclaimer")}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Steps.tsx
+++ b/src/sections/Steps.tsx
@@ -1,0 +1,21 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export function Steps(){
+  const { t } = useI18n();
+  const items = [t("steps.s1"), t("steps.s2"), t("steps.s3"), t("steps.s4")];
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-6xl px-6">
+        <h2 className="text-3xl font-semibold">{t("steps.title")}</h2>
+        <ol className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {items.map((label, i)=>(
+            <li key={i} className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[var(--brand)] text-[var(--brand-contrast)] font-bold">{i+1}</span>
+              <p className="mt-3">{label}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Testimonials.tsx
+++ b/src/sections/Testimonials.tsx
@@ -1,0 +1,22 @@
+import { useI18n } from '@/hooks/useI18n';
+
+export function Testimonials(){
+  const { t } = useI18n();
+  return (
+    <section className="py-16 bg-[var(--bg)]">
+      <div className="mx-auto max-w-6xl px-6">
+        <h2 className="text-3xl font-semibold">{t("socialProof.title")}</h2>
+        <div className="mt-8 grid gap-4 md:grid-cols-2">
+          <figure className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+            <blockquote>{t("socialProof.t1")}</blockquote>
+            <figcaption className="mt-3 text-sm text-[var(--muted)]">— Placeholder</figcaption>
+          </figure>
+          <figure className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+            <blockquote>{t("socialProof.t2")}</blockquote>
+            <figcaption className="mt-3 text-sm text-[var(--muted)]">— Placeholder</figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,20 @@
+:root{
+  --brand:#FF4A1C;
+  --brand-contrast:#111111;
+  --bg:#FFFFFF;
+  --fg:#0F1222;
+  --muted:#6B7280;
+  --card:#FFFFFF;
+  --border:#E5E7EB;
+  --ok:#16A34A;
+  --warn:#F59E0B;
+}
+:root.dark{
+  --brand:#FF4A1C;
+  --brand-contrast:#FFFFFF;
+  --bg:#0B0D14;
+  --fg:#E5E7EB;
+  --muted:#9CA3AF;
+  --card:#0F1222;
+  --border:#1F2433;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,12 +18,13 @@ export default {
 			}
 		},
 		extend: {
-			colors: {
-				border: 'hsl(var(--border))',
-				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
+                        colors: {
+                                brand: 'var(--brand)',
+                                border: 'hsl(var(--border))',
+                                input: 'hsl(var(--input))',
+                                ring: 'hsl(var(--ring))',
+                                background: 'hsl(var(--background))',
+                                foreground: 'hsl(var(--foreground))',
 				primary: {
 					DEFAULT: 'hsl(var(--primary))',
 					foreground: 'hsl(var(--primary-foreground))',

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": false,


### PR DESCRIPTION
## Summary
- add design tokens and Tailwind brand color mapping
- implement multilingual marketing sections with pricing logic and cookie consent
- wire up SEO tags and sitemap

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty, etc.)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acee946a54832bb436ac6a2198e314