### PR TITLE
Make eslint plugin optional so dev server runs without dev deps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,28 @@
 // vite.config.ts
-import { defineConfig, splitVendorChunkPlugin } from "vite";
+import { defineConfig, splitVendorChunkPlugin, type PluginOption } from "vite";
 import react from "@vitejs/plugin-react";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite"; // ✅ correct import
-import eslint from "vite-plugin-eslint";
+// The eslint plugin is optional: when running in an environment where
+// `vite-plugin-eslint` isn't installed (for example in a fresh CI
+// environment without dev dependencies), Vite used to throw a module
+// resolution error and the dev server failed to start.  We attempt to
+// load the plugin dynamically and simply skip it if it's not available.
+// This allows the application to run even when the plugin is missing.
+
+let eslintPlugin: PluginOption[] = [];
+try {
+  const { default: eslint } = await import("vite-plugin-eslint");
+  eslintPlugin = [eslint({ exclude: ["src/routeTree.gen.ts"] })];
+} catch {
+  // eslint plugin is not installed; continue without linting
+}
 
 export default defineConfig({
   base: "/",
   plugins: [
     react(),
     TanStackRouterVite(), // Corrected spelling, // Make sure this uses the correct imported name
-    eslint({ exclude: ["src/routeTree.gen.ts"] }),
+    ...eslintPlugin,
     splitVendorChunkPlugin(),
   ],
   resolve: { alias: { "@": "/src" } },


### PR DESCRIPTION
## Summary
- load `vite-plugin-eslint` dynamically and skip when missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 87 errors)*
- `npm run typecheck`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68ad04916d74832b89748d7f131d6f10